### PR TITLE
Propagate littleh units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Moved some mathematical operations out of return statements to save memory
 - Various typos
+- Propagated `littleh_units` keyword up to `calculate_delay_spectrum` function.
 - Docstring Formatting
 - Moved all cosmological calculations to update_cosmology function
 ### Fixed

--- a/simpleDS/delay_spectrum.py
+++ b/simpleDS/delay_spectrum.py
@@ -855,7 +855,7 @@ class DelaySpectrum(UVBase):
         """Update cosmological information with the assumed cosmology.
 
         Arguments:
-            cosmo: input assumed cosmology. Must be an astropy cosmology object.
+            cosmology: input assumed cosmology. Must be an astropy cosmology object.
             littleh_units: (Bool, default:False)
                            automatically convert to to mK^2 / (litlteh / Mpc)^3. Only applies in python 3.
         """
@@ -1072,11 +1072,20 @@ class DelaySpectrum(UVBase):
         return noise_power.to('Jy')
 
     def calculate_delay_spectrum(self, run_check=True,
-                                 run_check_acceptability=True):
+                                 run_check_acceptability=True,
+                                 cosmology=None,
+                                 littleh_units=False):
         """Perform Delay tranform and cross multiplication of datas.
 
         Take the normalized Fourier transform of the data in objects and cross multiplies baselines.
         Also generates white noise given the frequency range and trcvr and calculates the expected noise power.
+
+        Arguments:
+            cosmology: Astropy.Cosmology subclass
+                   Default: None (uses cosmology object saved in self.cosmology)
+                   input assumed cosmology. Must be an astropy cosmology object. Setting this value will overwrite the cosmology set on the DelaySpectrum Object.
+            littleh_units: (Bool, default:False)
+                           automatically convert to to mK^2 / (litlteh / Mpc)^3. Only applies in python 3.
         """
         if self.Nuv == 0:
             raise ValueError("No data has be loaded. Add UVData objects before "
@@ -1097,7 +1106,7 @@ class DelaySpectrum(UVBase):
                                                           array_2=self.noise_array[:, 1],
                                                           axis=2)
         self.calculate_thermal_sensitivity()
-        self.update_cosmology()
+        self.update_cosmology(cosmology=cosmology, littleh_units=littleh_units)
 
     def calculate_thermal_sensitivity(self):
         """Calculate the Thermal sensitivity for the power spectrum.

--- a/simpleDS/tests/test_delay_spectrum.py
+++ b/simpleDS/tests/test_delay_spectrum.py
@@ -1103,7 +1103,7 @@ def test_update_cosmology_littleh_units():
 @sdstest.skipIf_py2
 def test_update_cosmology_littleh_units_from_calc_delay_spectr():
     """Test the units can convert to 'littleh' units in python 3 passed through calculate_delay_spectrum."""
-    testfile = os.path.join(UVDATA_PATH, 'test_redundant_array.uvh5')
+    testfile = os.path.join(UVDATA_PATH, 'test_redundant_array.uvfits')
     test_uvb_file = os.path.join(DATA_PATH, 'test_redundant_array.beamfits')
     test_cosmo = Planck15
     uvd = UVData()

--- a/simpleDS/tests/test_delay_spectrum.py
+++ b/simpleDS/tests/test_delay_spectrum.py
@@ -1098,3 +1098,24 @@ def test_update_cosmology_littleh_units():
     nt.assert_true(dspec_object.check())
     test_unit = (units.mK**2) / (units.littleh / units.Mpc)**3
     nt.assert_equal(dspec_object.power_array.unit, test_unit)
+
+
+@sdstest.skipIf_py2
+def test_update_cosmology_littleh_units_from_calc_delay_spectr():
+    """Test the units can convert to 'littleh' units in python 3 passed through calculate_delay_spectrum."""
+    testfile = os.path.join(UVDATA_PATH, 'test_redundant_array.uvh5')
+    test_uvb_file = os.path.join(DATA_PATH, 'test_redundant_array.beamfits')
+    test_cosmo = Planck15
+    uvd = UVData()
+    uvd.read(testfile)
+    dspec_object = DelaySpectrum(uv=[uvd])
+    dspec_object.select_spectral_windows([(1, 3), (4, 6)])
+    uvb = UVBeam()
+    uvb.read_beamfits(test_uvb_file)
+    dspec_object.add_uvbeam(uvb=uvb)
+    dspec_object.calculate_delay_spectrum(cosmology=test_cosmo, littleh_units=True)
+    nt.assert_true(dspec_object.check())
+
+    test_unit = (units.mK**2) / (units.littleh / units.Mpc)**3
+    nt.assert_equal(dspec_object.power_array.unit, test_unit)
+    nt.assert_equal(dspec_object.cosmology.name, 'Planck15')


### PR DESCRIPTION
propagates the `littleh_units` keyword up to `calculate_delay_spectrum` this way in python3 you can convert directly the power in `mK^2 /(littleh/Mpc)^3`