### PR TITLE
Minimum dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simple Delay Spectrum (SimpleDS)
 
-[![Build Status](https://travis-ci.org/RadioAstronomySoftwareGroup/simpleDS.svg?branch=master)](https://travis-ci.org/RadioAstronomySoftwareGroup/simpleDS)
+[![Build Status](https://travis-ci.com/RadioAstronomySoftwareGroup/simpleDS.svg?branch=master)](https://travis-ci.com/RadioAstronomySoftwareGroup/simpleDS)
 [![CircleCI](https://circleci.com/gh/RadioAstronomySoftwareGroup/simpleDS.svg?style=svg)](https://circleci.com/gh/RadioAstronomySoftwareGroup/simpleDS)
 [![Coverage Status](https://coveralls.io/repos/github/RadioAstronomySoftwareGroup/simpleDS/badge.svg)](https://coveralls.io/github/RadioAstronomySoftwareGroup/simpleDS)
 [![codecov](https://codecov.io/gh/RadioAstronomySoftwareGroup/simpleDS/branch/master/graph/badge.svg)](https://codecov.io/gh/RadioAstronomySoftwareGroup/simpleDS)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ First install dependencies.
 * scipy
 * astropy >= 2.0
 * h5py (for uvh5 compatibility with pyuvdata)
-* six (for compatibility between python 2 and 3)
+* six >= 1.10 (for compatibility between python 2 and 3)
 * pyuvdata (conda install -c conda-forge pyuvdata, `pip install pyuvdata`, or use the development version  https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git)
 
 For anaconda users, we suggest using conda to install astropy, numpy and scipy.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_args = {
                          'astropy>2.0',
                          'scipy',
                          'pyuvdata>=1.0',
-                         'six'],
+                         'six>=1.10'],
     'test_suite': 'nose'
 }
 

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,12 @@ setup_args = {
     'scripts': glob.glob('scripts/*'),
     'version': version.version,
     'include_package_data': True,
-    'install_requires': ['numpy>1.10', 'astropy>1.2', 'scipy',
-                         'nose', 'pyuvdata', 'six', 'h5py'],
+    'setup_requires': ['numpy>=1.15', 'six>=1.10'],
+    'install_requires': ['numpy>1.15',
+                         'astropy>2.0',
+                         'scipy',
+                         'pyuvdata>=1.0',
+                         'six'],
     'test_suite': 'nose'
 }
 


### PR DESCRIPTION
WIP: set explicit minimum dependencies. Will require next pyuvdata version (1.3.8) to be minimal once released (an I/O bug fixes for reading PAPER data in this version and uvh5 to uvfits changes affect test files).